### PR TITLE
Replace LiveKit TURN with coturn service

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -43,15 +43,11 @@ services:
     environment:
       LIVEKIT_KEYS: '${LIVEKIT_API_KEY}: ${LIVEKIT_API_SECRET}'
     volumes:
-      - caddy_data:/data:ro  # ← mount Caddy’s certs read-only into LiveKit
       - ./livekit/livekit.yaml:/etc/livekit/livekit.yaml:ro
     expose:
       - "7880"
       - "7881"
     ports:
-      - "65.109.242.173:3478:3478/udp" # Expose TURN port
-      - "65.109.242.173:443:443/tcp" # Expose TURN port
-      - "65.109.242.173:29000-29200:29000-29200/udp" # TURN relay range (your config!)
       - "46.62.140.249:7880:7880/tcp"
       - "46.62.140.249:7881:7881/tcp"
       - "46.62.140.249:7881:7881/udp"
@@ -59,6 +55,37 @@ services:
     restart: unless-stopped
     depends_on:
       - redis
+    networks:
+      - talkie-net
+
+  coturn:
+    image: coturn/coturn:4.6.2
+    command:
+      - --log-file=stdout
+      - --no-cli
+      - --fingerprint
+      - --realm=turn.talkie.k1nval.com
+      - --server-name=turn.talkie.k1nval.com
+      - --use-auth-secret
+      # Replace the default secret via TURN_STATIC_AUTH_SECRET in production.
+      - --static-auth-secret=${TURN_STATIC_AUTH_SECRET:-talkie-turn-shared-secret}
+      - --listening-port=3478
+      - --min-port=29000
+      - --max-port=29200
+      - --tls-listening-port=443
+      - --external-ip=65.109.242.173
+      - --cert=/data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/turn.talkie.k1nval.com/turn.talkie.k1nval.com.crt
+      - --pkey=/data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/turn.talkie.k1nval.com/turn.talkie.k1nval.com.key
+    volumes:
+      - caddy_data:/data:ro
+    ports:
+      - "65.109.242.173:3478:3478/udp"
+      - "65.109.242.173:3478:3478/tcp"
+      - "65.109.242.173:443:443/tcp"
+      - "65.109.242.173:29000-29200:29000-29200/udp"
+    restart: unless-stopped
+    depends_on:
+      - caddy
     networks:
       - talkie-net
 
@@ -74,6 +101,7 @@ services:
       - caddy_data:/data
     ports:
       - "46.62.140.249:80:80/tcp"
+      - "65.109.242.173:80:80/tcp" # Allow Caddy to solve ACME for the TURN domain
       - "46.62.140.249:443:443/tcp"
       - "46.62.140.249:443:443/udp"
     restart: unless-stopped

--- a/infra/livekit/livekit.yaml
+++ b/infra/livekit/livekit.yaml
@@ -15,12 +15,10 @@ logging:
 redis:
   address: redis:6379
 turn:
-  enabled: true
-  udp_port: 3478
-  tls_port: 443
-  relay_range_start: 29000        # narrow TURN relay pool
-  relay_range_end:   29200  
-  external_tls: false     # LiveKit will do TLS itself
-  domain: turn.talkie.k1nval.com
-  cert_file: /data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/turn.talkie.k1nval.com/turn.talkie.k1nval.com.crt
-  key_file:  /data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/turn.talkie.k1nval.com/turn.talkie.k1nval.com.key
+  enabled: false
+  # Must match the TURN static auth secret used by the coturn service.
+  secret: talkie-turn-shared-secret
+  external_servers:
+    - urls:
+      - turn:turn.talkie.k1nval.com:3478?transport=udp
+      - turns:turn.talkie.k1nval.com:443?transport=tcp


### PR DESCRIPTION
## Summary
- add a dedicated coturn container that exposes TURN traffic on the second public IP and shares certificates from Caddy
- disable LiveKit's embedded TURN server and point it to the external coturn instance
- let Caddy answer ACME challenges for the TURN domain on the coturn IP so certificates stay refreshed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c94a4687c88326aba40b7f2ac243fd