### PR TITLE
Add audio-only room support with microphone controls

### DIFF
--- a/apps/web/lib/audio/GainAudioProcessor.ts
+++ b/apps/web/lib/audio/GainAudioProcessor.ts
@@ -1,0 +1,70 @@
+import type { AudioProcessorOptions, TrackProcessor, Track } from 'livekit-client';
+
+export class GainAudioProcessor implements TrackProcessor<Track.Kind.Audio, AudioProcessorOptions> {
+  name = 'gain-audio-processor';
+
+  processedTrack?: MediaStreamTrack;
+  private context?: AudioContext;
+  private source?: MediaStreamAudioSourceNode;
+  private destination?: MediaStreamAudioDestinationNode;
+  private gainNode?: GainNode;
+  private stream?: MediaStream;
+  private gainValue: number;
+
+  constructor(initialGain = 1) {
+    this.gainValue = initialGain;
+  }
+
+  async init(options: AudioProcessorOptions) {
+    this.context = options.audioContext;
+    this.setupNodes(options.track);
+  }
+
+  async restart(options: AudioProcessorOptions) {
+    this.teardown();
+    this.context = options.audioContext;
+    this.setupNodes(options.track);
+  }
+
+  async destroy() {
+    this.teardown();
+  }
+
+  setGain(gain: number) {
+    this.gainValue = gain;
+    if (this.gainNode) {
+      this.gainNode.gain.value = gain;
+    }
+  }
+
+  private setupNodes(track: MediaStreamTrack) {
+    if (!this.context) {
+      return;
+    }
+
+    this.stream = new MediaStream([track]);
+    this.source = this.context.createMediaStreamSource(this.stream);
+    this.destination = this.context.createMediaStreamDestination();
+    this.gainNode = this.context.createGain();
+    this.gainNode.gain.value = this.gainValue;
+
+    this.source.connect(this.gainNode).connect(this.destination);
+
+    const [processedTrack] = this.destination.stream.getAudioTracks();
+    if (processedTrack) {
+      this.processedTrack = processedTrack;
+    }
+  }
+
+  private teardown() {
+    this.source?.disconnect();
+    this.gainNode?.disconnect();
+    this.destination?.disconnect();
+    this.processedTrack?.stop();
+
+    this.processedTrack = undefined;
+    this.source = undefined;
+    this.destination = undefined;
+    this.stream = undefined;
+  }
+}

--- a/apps/web/lib/audio/RemoteParticipantAudioMixer.ts
+++ b/apps/web/lib/audio/RemoteParticipantAudioMixer.ts
@@ -1,0 +1,122 @@
+import { RemoteAudioTrack } from 'livekit-client';
+
+interface ParticipantNodes {
+  track: RemoteAudioTrack;
+  stream: MediaStream;
+  source: MediaStreamAudioSourceNode;
+  gainNode: GainNode;
+}
+
+/**
+ * RemoteParticipantAudioMixer wires remote LiveKit audio tracks through a GainNode so we can
+ * adjust per-participant playback levels without touching what other listeners hear.
+ */
+export class RemoteParticipantAudioMixer {
+  private readonly audioContext: AudioContext;
+
+  private readonly destination: AudioNode;
+
+  private readonly participants = new Map<string, ParticipantNodes>();
+
+  private readonly volumeMemory = new Map<string, number>();
+
+  constructor() {
+    this.audioContext = new AudioContext();
+    this.destination = this.audioContext.destination;
+  }
+
+  /**
+   * Attach a remote microphone track to the Web Audio graph and remember its preferred volume.
+   */
+  connectTrack(identity: string, track: RemoteAudioTrack, volume: number): void {
+    const existing = this.participants.get(identity);
+
+    if (existing?.track === track) {
+      existing.gainNode.gain.value = volume;
+      this.volumeMemory.set(identity, volume);
+      return;
+    }
+
+    if (existing) {
+      this.disconnectParticipant(identity);
+    }
+
+    const stream = new MediaStream([track.mediaStreamTrack]);
+    const source = this.audioContext.createMediaStreamSource(stream);
+    const gainNode = this.audioContext.createGain();
+
+    gainNode.gain.value = volume;
+    source.connect(gainNode);
+    gainNode.connect(this.destination);
+
+    this.participants.set(identity, { track, stream, source, gainNode });
+    this.volumeMemory.set(identity, volume);
+    void this.resume();
+  }
+
+  /**
+   * Update the stored gain value for a participant. This only affects the local mix.
+   */
+  setVolume(identity: string, volume: number): void {
+    this.volumeMemory.set(identity, volume);
+    const nodes = this.participants.get(identity);
+
+    if (nodes) {
+      nodes.gainNode.gain.value = volume;
+    }
+  }
+
+  /**
+   * Remove a participant from the graph when their track unsubscribes or they leave.
+   */
+  disconnectParticipant(identity: string): void {
+    const nodes = this.participants.get(identity);
+
+    if (!nodes) {
+      return;
+    }
+
+    nodes.source.disconnect();
+    nodes.gainNode.disconnect();
+    this.participants.delete(identity);
+  }
+
+  /**
+   * True when we currently mix audio for the given participant.
+   */
+  hasParticipant(identity: string): boolean {
+    return this.participants.has(identity);
+  }
+
+  /**
+   * Retrieve the last requested gain for a participant, defaulting to unity (1.0).
+   */
+  getVolume(identity: string): number {
+    return this.volumeMemory.get(identity) ?? 1;
+  }
+
+  /**
+   * Resume the audio context if the browser suspended it.
+   */
+  async resume(): Promise<void> {
+    if (this.audioContext.state === 'suspended') {
+      try {
+        await this.audioContext.resume();
+      } catch (error) {
+        console.warn('Failed to resume audio context', error);
+      }
+    }
+  }
+
+  /**
+   * Tear down the graph so garbage collection can release the audio context.
+   */
+  destroy(): void {
+    this.participants.forEach((nodes) => {
+      nodes.source.disconnect();
+      nodes.gainNode.disconnect();
+    });
+    this.participants.clear();
+    void this.audioContext.close();
+  }
+}

--- a/apps/web/lib/audio/useRemoteParticipantAudio.ts
+++ b/apps/web/lib/audio/useRemoteParticipantAudio.ts
@@ -1,0 +1,106 @@
+import { TrackReference } from '@livekit/components-core';
+import { RemoteAudioTrack } from 'livekit-client';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { RemoteParticipantAudioMixer } from './RemoteParticipantAudioMixer';
+
+interface RemoteParticipantAudioState {
+  volumes: Record<string, number>;
+  setVolume: (identity: string, volume: number) => void;
+}
+
+/**
+ * Hook that keeps a RemoteParticipantAudioMixer in sync with the current remote tracks and exposes
+ * a simple volume map that React components can render.
+ */
+export function useRemoteParticipantAudio(tracks: TrackReference[]): RemoteParticipantAudioState {
+  const mixerRef = useRef<RemoteParticipantAudioMixer | null>(null);
+  const volumeMemoryRef = useRef<Record<string, number>>({});
+  const activeVolumesRef = useRef<Record<string, number>>({});
+  const [volumes, setVolumes] = useState<Record<string, number>>({});
+
+  const mixer = useMemo(() => {
+    if (!mixerRef.current) {
+      mixerRef.current = new RemoteParticipantAudioMixer();
+    }
+    return mixerRef.current;
+  }, []);
+
+  useEffect(() => {
+    const nextVolumes: Record<string, number> = {};
+    const seenIdentities = new Set<string>();
+
+    tracks.forEach((trackRef) => {
+      if (trackRef.participant.isLocal) {
+        return;
+      }
+
+      const identity = trackRef.participant.identity;
+      const liveTrack = trackRef.publication?.track;
+      const storedVolume = volumeMemoryRef.current[identity] ?? 1;
+
+      seenIdentities.add(identity);
+      volumeMemoryRef.current[identity] = storedVolume;
+      nextVolumes[identity] = storedVolume;
+
+      if (liveTrack instanceof RemoteAudioTrack) {
+        mixer.connectTrack(identity, liveTrack, storedVolume);
+      } else {
+        if (mixer.hasParticipant(identity)) {
+          mixer.disconnectParticipant(identity);
+        }
+      }
+    });
+
+    Object.keys(activeVolumesRef.current).forEach((identity) => {
+      if (!seenIdentities.has(identity)) {
+        mixer.disconnectParticipant(identity);
+      }
+    });
+
+    const changed = hasVolumeChanges(activeVolumesRef.current, nextVolumes);
+
+    if (changed) {
+      activeVolumesRef.current = nextVolumes;
+      setVolumes({ ...nextVolumes });
+    }
+  }, [mixer, tracks]);
+
+  const setVolume = useCallback(
+    (identity: string, volume: number) => {
+      volumeMemoryRef.current = { ...volumeMemoryRef.current, [identity]: volume };
+      activeVolumesRef.current = { ...activeVolumesRef.current, [identity]: volume };
+      setVolumes({ ...activeVolumesRef.current });
+      mixer.setVolume(identity, volume);
+    },
+    [mixer],
+  );
+
+  useEffect(() => {
+    return () => {
+      mixerRef.current?.destroy();
+      mixerRef.current = null;
+    };
+  }, []);
+
+  return { volumes, setVolume };
+}
+
+function hasVolumeChanges(
+  prev: Record<string, number>,
+  next: Record<string, number>,
+): boolean {
+  const prevKeys = Object.keys(prev);
+  const nextKeys = Object.keys(next);
+
+  if (prevKeys.length !== nextKeys.length) {
+    return true;
+  }
+
+  for (const key of nextKeys) {
+    if (prev[key] !== next[key]) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Disable minification to aid debugging production issues
+  swcMinify: false,
 };
 
 export default nextConfig;

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,6 +4,14 @@ const nextConfig = {
   // Disable minification and expose source maps to aid debugging production issues
   swcMinify: false,
   productionBrowserSourceMaps: true,
+  webpack(config, { dev }) {
+    if (!dev) {
+      config.optimization.minimize = false;
+      config.optimization.minimizer = [];
+    }
+
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,8 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // Disable minification to aid debugging production issues
+  // Disable minification and expose source maps to aid debugging production issues
   swcMinify: false,
+  productionBrowserSourceMaps: true,
 };
 
 export default nextConfig;

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -13,12 +13,14 @@ export default function Home() {
   const router = useRouter();
 
   useEffect(() => {
+    // Load the available rooms once on mount so the lobby shows up-to-date options.
     fetch(process.env.NEXT_PUBLIC_API_URL + '/rooms')
       .then((res) => res.json())
       .then((data) => setRooms(data.rooms));
   }, []);
 
   const handleJoin = (room: RoomSummary) => {
+    // Encode the room name so we can safely use it inside the URL.
     router.push(`/room/${encodeURIComponent(room.name)}`);
   };
 

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,8 +1,15 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
+type RoomType = 'Video' | 'Audio';
+
+interface RoomSummary {
+  name: string;
+  type: RoomType;
+}
+
 export default function Home() {
-  const [rooms, setRooms] = useState<string[]>([]);
+  const [rooms, setRooms] = useState<RoomSummary[]>([]);
   const router = useRouter();
 
   useEffect(() => {
@@ -11,8 +18,8 @@ export default function Home() {
       .then((data) => setRooms(data.rooms));
   }, []);
 
-  const handleJoin = (roomName: string) => {
-    router.push(`/room/${encodeURIComponent(roomName)}`);
+  const handleJoin = (room: RoomSummary) => {
+    router.push(`/room/${encodeURIComponent(room.name)}`);
   };
 
   return (
@@ -21,12 +28,13 @@ export default function Home() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {rooms.map((room) => (
           <button
-            key={room}
+            key={room.name}
             onClick={() => handleJoin(room)}
             style={{ height: '100px', width: '100%', margin: '10px' }}
             className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-4 px-8 rounded-lg shadow-lg transition-transform transform hover:scale-105"
           >
-            {room}
+            <div className="text-lg font-semibold">{room.name}</div>
+            <div className="text-sm text-blue-100 mt-1">{room.type === 'Audio' ? 'Аудио' : 'Видео'}</div>
           </button>
         ))}
       </div>

--- a/apps/web/pages/room/[roomName].tsx
+++ b/apps/web/pages/room/[roomName].tsx
@@ -6,12 +6,18 @@ import {
   LiveKitRoom,
   ParticipantTile,
   RoomAudioRenderer,
+  useLocalParticipant,
+  useMediaDeviceSelect,
+  useParticipants,
   useTracks,
 } from '@livekit/components-react';
-import { Track } from 'livekit-client';
+import { LocalAudioTrack, Track } from 'livekit-client';
 import { useRouter } from 'next/router';
-import { CSSProperties, useEffect, useState } from 'react';
+import { ChangeEvent, CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 import { TrackReference } from '@livekit/components-core';
+import { GainAudioProcessor } from '../../lib/audio/GainAudioProcessor';
+
+type RoomType = 'Video' | 'Audio';
 
 const styles: Record<string, CSSProperties> = {
   container: {
@@ -19,6 +25,11 @@ const styles: Record<string, CSSProperties> = {
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-between',
+  },
+  audioContainer: {
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
   },
   videoContainer: {
     minHeight: '0',
@@ -88,24 +99,203 @@ function MyVideoConference({ pinnedTrack }: MyVideoConferenceProps) {
   );
 }
 
+interface AudioRoomViewProps {
+  roomName: string;
+  participantName: string | null;
+}
+
+function AudioRoomView({ roomName, participantName }: AudioRoomViewProps) {
+  const participants = useParticipants();
+  const { microphoneTrack } = useLocalParticipant();
+  const { devices, activeDeviceId, setActiveMediaDevice } = useMediaDeviceSelect({ kind: 'audioinput' });
+  const [inputVolume, setInputVolume] = useState(1);
+  const volumeRef = useRef(inputVolume);
+  const processorRef = useRef<GainAudioProcessor | null>(null);
+  const appliedTrackRef = useRef<LocalAudioTrack | null>(null);
+
+  useEffect(() => {
+    volumeRef.current = inputVolume;
+    processorRef.current?.setGain(inputVolume);
+  }, [inputVolume]);
+
+  useEffect(() => {
+    const track = (microphoneTrack?.track as LocalAudioTrack) ?? null;
+
+    if (!track) {
+      appliedTrackRef.current = null;
+      return;
+    }
+
+    const processor = processorRef.current ?? new GainAudioProcessor(volumeRef.current);
+    processorRef.current = processor;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await track.setProcessor(processor);
+        if (cancelled) {
+          await track.stopProcessor().catch(() => undefined);
+          return;
+        }
+        processor.setGain(volumeRef.current);
+        appliedTrackRef.current = track;
+      } catch (error) {
+        console.error('Failed to apply input volume processor', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (appliedTrackRef.current === track) {
+        track.stopProcessor().catch((error) => {
+          console.warn('Failed to remove input processor', error);
+        });
+        appliedTrackRef.current = null;
+      }
+    };
+  }, [microphoneTrack?.track]);
+
+  const sortedParticipants = useMemo(() => {
+    return [...participants].sort((a, b) => {
+      if (a.isLocal === b.isLocal) {
+        return a.identity.localeCompare(b.identity);
+      }
+      return a.isLocal ? -1 : 1;
+    });
+  }, [participants]);
+
+  const currentDeviceId = activeDeviceId && activeDeviceId !== '' ? activeDeviceId : 'default';
+  const canChangeDevice = devices.length > 0;
+
+  const handleDeviceChange = async (event: ChangeEvent<HTMLSelectElement>) => {
+    const deviceId = event.target.value;
+    try {
+      await setActiveMediaDevice(deviceId);
+    } catch (error) {
+      console.error('Failed to switch audio input device', error);
+    }
+  };
+
+  const handleVolumeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setInputVolume(Number(event.target.value));
+  };
+
+  const participantCount = participants.length;
+
+  return (
+    <div className="flex flex-1 flex-col items-center gap-6 bg-gray-900 text-white p-6 overflow-y-auto w-full">
+      <div className="w-full max-w-3xl flex flex-col gap-6">
+        <header className="space-y-1">
+          <h2 className="text-2xl font-semibold">Комната: {roomName}</h2>
+          {participantName && <p className="text-sm text-gray-300">Вы вошли как {participantName}</p>}
+          <p className="text-sm text-gray-400">Участников: {participantCount}</p>
+        </header>
+        <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
+          <h3 className="text-lg font-semibold mb-3">Участники</h3>
+          {sortedParticipants.length > 0 ? (
+            <ul className="space-y-2">
+              {sortedParticipants.map((participant) => (
+                <li
+                  key={participant.identity}
+                  className={`flex items-center justify-between rounded-lg px-3 py-2 transition-colors ${
+                    participant.isSpeaking ? 'bg-blue-600/40' : 'bg-gray-900/60'
+                  }`}
+                >
+                  <span className="font-medium">
+                    {participant.name ?? participant.identity}
+                    {participant.isLocal ? ' (Вы)' : ''}
+                  </span>
+                  {participant.isSpeaking && (
+                    <span className="text-xs uppercase tracking-wider text-blue-200">Говорит</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-400">Пока никого нет</p>
+          )}
+        </div>
+        <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4 space-y-4">
+          <div>
+            <label className="flex items-center justify-between text-sm font-medium text-gray-200">
+              <span>Громкость микрофона</span>
+              <span>{Math.round(inputVolume * 100)}%</span>
+            </label>
+            <input
+              type="range"
+              min={0}
+              max={2}
+              step={0.05}
+              value={inputVolume}
+              onChange={handleVolumeChange}
+              className="mt-2 w-full accent-blue-500"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium text-gray-200" htmlFor="audio-input-select">
+              Устройство ввода
+            </label>
+            <select
+              id="audio-input-select"
+              className="mt-2 w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={canChangeDevice ? currentDeviceId : ''}
+              onChange={handleDeviceChange}
+              disabled={!canChangeDevice}
+            >
+              {canChangeDevice ? (
+                devices.map((device, index) => (
+                  <option key={device.deviceId || device.label || index} value={device.deviceId || 'default'}>
+                    {device.label || `Микрофон ${index + 1}`}
+                  </option>
+                ))
+              ) : (
+                <option value="">Нет доступных устройств</option>
+              )}
+            </select>
+          </div>
+        </div>
+        <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
+          <ControlBar
+            controls={{ microphone: true, camera: false, screenShare: false, chat: false, leave: true }}
+            variation="minimal"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function RoomPage() {
   const [token, setToken] = useState<string | null>(null);
   const [wsUrl, setWsUrl] = useState<string | null>(null);
+  const [roomType, setRoomType] = useState<RoomType | null>(null);
+  const [participantName, setParticipantName] = useState<string | null>(null);
   const [pinnedTrack, setPinnedTrack] = useState<TrackReference | null>(null);
   const router = useRouter();
   const { roomName } = router.query;
 
+  const normalizedRoomName = typeof roomName === 'string' ? roomName : roomName?.[0];
+
   useEffect(() => {
-    if (!roomName) return;
+    if (!normalizedRoomName) return;
 
     const joinRoom = async () => {
-      const resp = await fetch(process.env.NEXT_PUBLIC_API_URL + `/rooms/${roomName}/join`, {
-        method: 'POST',
-      });
+      const resp = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/rooms/${encodeURIComponent(normalizedRoomName)}/join`,
+        {
+          method: 'POST',
+        },
+      );
 
       if (!resp.ok) {
-        const error = await resp.json();
-        alert(`Failed to join room: ${error.error}`);
+        let errorMessage = 'Не удалось подключиться к комнате';
+        try {
+          const error = await resp.json();
+          errorMessage = error.error ?? errorMessage;
+        } catch (error) {
+          console.error('Failed to parse join error', error);
+        }
+        alert(`Failed to join room: ${errorMessage}`);
         router.push('/');
         return;
       }
@@ -113,16 +303,22 @@ export default function RoomPage() {
       const data = await resp.json();
       setToken(data.token);
       setWsUrl(data.wsUrl);
+      setRoomType(data.type as RoomType);
+      setParticipantName(data.name ?? null);
     };
 
     joinRoom();
-  }, [roomName, router]);
+  }, [normalizedRoomName, router]);
 
   const onDisconnected = () => {
     router.push('/');
   };
 
-  if (!token || !wsUrl) {
+  if (!normalizedRoomName) {
+    return <div>Loading...</div>;
+  }
+
+  if (!token || !wsUrl || !roomType) {
     return <div>Loading...</div>;
   }
 
@@ -131,34 +327,38 @@ export default function RoomPage() {
       serverUrl={wsUrl}
       token={token}
       connect
-      video={true}
+      video={roomType === 'Video'}
       audio={true}
       onDisconnected={onDisconnected}
       data-lk-theme="default"
-      style={styles.container}
+      style={roomType === 'Video' ? styles.container : styles.audioContainer}
     >
-      <LayoutContextProvider
-        onPinChange={(state) => {
-          if (state.length > 0) {
-            setPinnedTrack(state[0]);
-          } else {
-            setPinnedTrack(null);
-          }
-        }}
-      >
-        <MyVideoConference pinnedTrack={pinnedTrack} />
-        <div style={styles.controlBar}>
-          <ControlBar
-            controls={{
-              microphone: true,
-              camera: true,
-              screenShare: false, // Disabling screen share for 1:1
-              chat: false, // Disabling chat for now
-              leave: true,
-            }}
-          />
-        </div>
-      </LayoutContextProvider>
+      {roomType === 'Video' ? (
+        <LayoutContextProvider
+          onPinChange={(state) => {
+            if (state.length > 0) {
+              setPinnedTrack(state[0]);
+            } else {
+              setPinnedTrack(null);
+            }
+          }}
+        >
+          <MyVideoConference pinnedTrack={pinnedTrack} />
+          <div style={styles.controlBar}>
+            <ControlBar
+              controls={{
+                microphone: true,
+                camera: true,
+                screenShare: false, // Disabling screen share for 1:1
+                chat: false, // Disabling chat for now
+                leave: true,
+              }}
+            />
+          </div>
+        </LayoutContextProvider>
+      ) : (
+        <AudioRoomView roomName={normalizedRoomName} participantName={participantName} />
+      )}
       <RoomAudioRenderer />
     </LiveKitRoom>
   );

--- a/apps/web/pages/room/[roomName].tsx
+++ b/apps/web/pages/room/[roomName].tsx
@@ -11,11 +11,21 @@ import {
   useParticipants,
   useTracks,
 } from '@livekit/components-react';
+import type { TrackReference } from '@livekit/components-core';
+import type { Participant } from 'livekit-client';
 import { LocalAudioTrack, Track } from 'livekit-client';
 import { useRouter } from 'next/router';
-import { ChangeEvent, CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
-import { TrackReference } from '@livekit/components-core';
+import {
+  ChangeEvent,
+  CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { GainAudioProcessor } from '../../lib/audio/GainAudioProcessor';
+import { useRemoteParticipantAudio } from '../../lib/audio/useRemoteParticipantAudio';
 
 type RoomType = 'Video' | 'Audio';
 
@@ -103,6 +113,250 @@ function MyVideoConference({ pinnedTrack }: MyVideoConferenceProps) {
   );
 }
 
+interface AudioRoomHeaderProps {
+  roomName: string;
+  participantName: string | null;
+  participantCount: number;
+}
+
+/**
+ * Presents the room title and attendance stats so the main layout stays tidy.
+ */
+function AudioRoomHeader({ roomName, participantName, participantCount }: AudioRoomHeaderProps) {
+  return (
+    <header className="space-y-1">
+      <h2 className="text-2xl font-semibold">Комната: {roomName}</h2>
+      {participantName && <p className="text-sm text-gray-300">Вы вошли как {participantName}</p>}
+      <p className="text-sm text-gray-400">Участников: {participantCount}</p>
+    </header>
+  );
+}
+
+interface ParticipantListProps {
+  participants: Participant[];
+  volumes: Record<string, number>;
+  onVolumeChange: (identity: string, volume: number) => void;
+}
+
+/**
+ * Renders every attendee with optional per-participant gain sliders for remote voices.
+ */
+function ParticipantList({ participants, volumes, onVolumeChange }: ParticipantListProps) {
+  if (participants.length === 0) {
+    return (
+      <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
+        <h3 className="text-lg font-semibold mb-3">Участники</h3>
+        <p className="text-sm text-gray-400">Пока никого нет</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
+      <h3 className="text-lg font-semibold mb-3">Участники</h3>
+      <ul className="space-y-2">
+        {participants.map((participant) => (
+          <ParticipantRow
+            key={participant.identity}
+            participant={participant}
+            volume={volumes[participant.identity] ?? 1}
+            onVolumeChange={onVolumeChange}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface ParticipantRowProps {
+  participant: Participant;
+  volume: number;
+  onVolumeChange: (identity: string, volume: number) => void;
+}
+
+/**
+ * Keeps the participant card compact while exposing a gain slider for remote voices.
+ */
+function ParticipantRow({ participant, volume, onVolumeChange }: ParticipantRowProps) {
+  const displayName = participant.name ?? participant.identity;
+  const isLocal = participant.isLocal;
+
+  return (
+    <li
+      className={`flex flex-col gap-3 rounded-lg px-3 py-2 transition-colors sm:flex-row sm:items-center sm:justify-between ${
+        participant.isSpeaking ? 'bg-blue-600/40' : 'bg-gray-900/60'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2 sm:gap-3">
+        <span className="font-medium">
+          {displayName}
+          {isLocal ? ' (Вы)' : ''}
+        </span>
+        {participant.isSpeaking && (
+          <span className="text-xs uppercase tracking-wider text-blue-200">Говорит</span>
+        )}
+      </div>
+      {!isLocal && (
+        <ParticipantVolumeSlider
+          identity={participant.identity}
+          volume={volume}
+          onVolumeChange={onVolumeChange}
+        />
+      )}
+    </li>
+  );
+}
+
+interface ParticipantVolumeSliderProps {
+  identity: string;
+  volume: number;
+  onVolumeChange: (identity: string, volume: number) => void;
+}
+
+/**
+ * Slider component that reports gain changes back to the mixer hook.
+ */
+function ParticipantVolumeSlider({ identity, volume, onVolumeChange }: ParticipantVolumeSliderProps) {
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onVolumeChange(identity, Number(event.target.value));
+    },
+    [identity, onVolumeChange],
+  );
+
+  return (
+    <div className="flex w-full items-center gap-3 sm:w-64">
+      <label className="text-xs font-medium text-gray-400" htmlFor={`volume-${identity}`}>
+        {Math.round(volume * 100)}%
+      </label>
+      <input
+        id={`volume-${identity}`}
+        type="range"
+        min={0}
+        max={2}
+        step={0.05}
+        value={volume}
+        onChange={handleChange}
+        className="flex-1 accent-blue-500"
+        aria-label="Громкость участника"
+      />
+    </div>
+  );
+}
+
+interface AudioSettingsPanelProps {
+  inputVolume: number;
+  onInputVolumeChange: (value: number) => void;
+  noiseCancellationEnabled: boolean;
+  onNoiseCancellationToggle: (enabled: boolean) => void;
+  devices: MediaDeviceInfo[];
+  canChangeDevice: boolean;
+  currentDeviceId: string;
+  onDeviceChange: (deviceId: string) => void;
+}
+
+/**
+ * Groups microphone controls so the audio room stays approachable for new users.
+ */
+function AudioSettingsPanel({
+  inputVolume,
+  onInputVolumeChange,
+  noiseCancellationEnabled,
+  onNoiseCancellationToggle,
+  devices,
+  canChangeDevice,
+  currentDeviceId,
+  onDeviceChange,
+}: AudioSettingsPanelProps) {
+  const handleVolumeChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onInputVolumeChange(Number(event.target.value));
+    },
+    [onInputVolumeChange],
+  );
+
+  const handleNoiseChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onNoiseCancellationToggle(event.target.checked);
+    },
+    [onNoiseCancellationToggle],
+  );
+
+  const handleDeviceChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      onDeviceChange(event.target.value);
+    },
+    [onDeviceChange],
+  );
+
+  return (
+    <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4 space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-200">Шумоподавление</h3>
+          <p className="text-xs text-gray-400">Использует встроенную фильтрацию браузера.</p>
+        </div>
+        <label className="inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            className="sr-only"
+            checked={noiseCancellationEnabled}
+            onChange={handleNoiseChange}
+          />
+          <span
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+              noiseCancellationEnabled ? 'bg-blue-500' : 'bg-gray-600'
+            }`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${
+                noiseCancellationEnabled ? 'translate-x-5' : 'translate-x-1'
+              }`}
+            />
+          </span>
+        </label>
+      </div>
+      <div>
+        <label className="flex items-center justify-between text-sm font-medium text-gray-200">
+          <span>Громкость микрофона</span>
+          <span>{Math.round(inputVolume * 100)}%</span>
+        </label>
+        <input
+          type="range"
+          min={0}
+          max={2}
+          step={0.05}
+          value={inputVolume}
+          onChange={handleVolumeChange}
+          className="mt-2 w-full accent-blue-500"
+        />
+      </div>
+      <div>
+        <label className="text-sm font-medium text-gray-200" htmlFor="audio-input-select">
+          Устройство ввода
+        </label>
+        <select
+          id="audio-input-select"
+          className="mt-2 w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          value={canChangeDevice ? currentDeviceId : ''}
+          onChange={handleDeviceChange}
+          disabled={!canChangeDevice}
+        >
+          {canChangeDevice ? (
+            devices.map((device, index) => (
+              <option key={device.deviceId || device.label || index} value={device.deviceId || 'default'}>
+                {device.label || `Микрофон ${index + 1}`}
+              </option>
+            ))
+          ) : (
+            <option value="">Нет доступных устройств</option>
+          )}
+        </select>
+      </div>
+    </div>
+  );
+}
+
 interface AudioRoomViewProps {
   roomName: string;
   participantName: string | null;
@@ -120,6 +374,14 @@ function AudioRoomView({
   const { microphoneTrack } = useLocalParticipant();
   // LiveKit hook gives us the available audio input devices and lets us switch between them.
   const { devices, activeDeviceId, setActiveMediaDevice } = useMediaDeviceSelect({ kind: 'audioinput' });
+  const microphoneTracks = useTracks([{ source: Track.Source.Microphone }]);
+  const remoteMicrophoneTracks = useMemo(
+    () => microphoneTracks.filter((trackRef) => !trackRef.participant.isLocal),
+    [microphoneTracks],
+  );
+  const { volumes: playbackVolumes, setVolume: setParticipantPlaybackVolume } = useRemoteParticipantAudio(
+    remoteMicrophoneTracks,
+  );
   const [inputVolume, setInputVolume] = useState(1);
   const volumeRef = useRef(inputVolume);
   const processorRef = useRef<GainAudioProcessor | null>(null);
@@ -225,122 +487,60 @@ function AudioRoomView({
   const currentDeviceId = activeDeviceId && activeDeviceId !== '' ? activeDeviceId : 'default';
   const canChangeDevice = devices.length > 0;
 
-  const handleDeviceChange = async (event: ChangeEvent<HTMLSelectElement>) => {
-    const deviceId = event.target.value;
-    try {
-      await setActiveMediaDevice(deviceId);
-    } catch (error) {
-      console.error('Failed to switch audio input device', error);
-    }
-  };
+  const handleDeviceChange = useCallback(
+    async (deviceId: string) => {
+      try {
+        await setActiveMediaDevice(deviceId);
+      } catch (error) {
+        console.error('Failed to switch audio input device', error);
+      }
+    },
+    [setActiveMediaDevice],
+  );
 
-  const handleVolumeChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setInputVolume(Number(event.target.value));
-  };
+  const handleInputVolumeChange = useCallback((value: number) => {
+    setInputVolume(value);
+  }, []);
 
-  const handleNoiseCancellationChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onNoiseCancellationToggle(event.target.checked);
-  };
+  const handleNoiseCancellationChange = useCallback(
+    (enabled: boolean) => {
+      onNoiseCancellationToggle(enabled);
+    },
+    [onNoiseCancellationToggle],
+  );
+
+  const handleParticipantVolumeChange = useCallback(
+    (identity: string, value: number) => {
+      setParticipantPlaybackVolume(identity, value);
+    },
+    [setParticipantPlaybackVolume],
+  );
 
   const participantCount = participants.length;
 
   return (
     <div className="flex flex-1 flex-col items-center gap-6 bg-gray-900 text-white p-6 overflow-y-auto w-full">
       <div className="w-full max-w-3xl flex flex-col gap-6">
-        <header className="space-y-1">
-          <h2 className="text-2xl font-semibold">Комната: {roomName}</h2>
-          {participantName && <p className="text-sm text-gray-300">Вы вошли как {participantName}</p>}
-          <p className="text-sm text-gray-400">Участников: {participantCount}</p>
-        </header>
-        <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
-          <h3 className="text-lg font-semibold mb-3">Участники</h3>
-          {sortedParticipants.length > 0 ? (
-            <ul className="space-y-2">
-              {sortedParticipants.map((participant) => (
-                <li
-                  key={participant.identity}
-                  className={`flex items-center justify-between rounded-lg px-3 py-2 transition-colors ${
-                    participant.isSpeaking ? 'bg-blue-600/40' : 'bg-gray-900/60'
-                  }`}
-                >
-                  <span className="font-medium">
-                    {participant.name ?? participant.identity}
-                    {participant.isLocal ? ' (Вы)' : ''}
-                  </span>
-                  {participant.isSpeaking && (
-                    <span className="text-xs uppercase tracking-wider text-blue-200">Говорит</span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-sm text-gray-400">Пока никого нет</p>
-          )}
-        </div>
-        <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4 space-y-4">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h3 className="text-sm font-semibold text-gray-200">Шумоподавление</h3>
-              <p className="text-xs text-gray-400">Использует встроенную фильтрацию браузера.</p>
-            </div>
-            <label className="inline-flex items-center cursor-pointer">
-              <input
-                type="checkbox"
-                className="sr-only"
-                checked={noiseCancellationEnabled}
-                onChange={handleNoiseCancellationChange}
-              />
-              <span
-                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                  noiseCancellationEnabled ? 'bg-blue-500' : 'bg-gray-600'
-                }`}
-              >
-                <span
-                  className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${
-                    noiseCancellationEnabled ? 'translate-x-5' : 'translate-x-1'
-                  }`}
-                />
-              </span>
-            </label>
-          </div>
-          <div>
-            <label className="flex items-center justify-between text-sm font-medium text-gray-200">
-              <span>Громкость микрофона</span>
-              <span>{Math.round(inputVolume * 100)}%</span>
-            </label>
-            <input
-              type="range"
-              min={0}
-              max={2}
-              step={0.05}
-              value={inputVolume}
-              onChange={handleVolumeChange}
-              className="mt-2 w-full accent-blue-500"
-            />
-          </div>
-          <div>
-            <label className="text-sm font-medium text-gray-200" htmlFor="audio-input-select">
-              Устройство ввода
-            </label>
-            <select
-              id="audio-input-select"
-              className="mt-2 w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              value={canChangeDevice ? currentDeviceId : ''}
-              onChange={handleDeviceChange}
-              disabled={!canChangeDevice}
-            >
-              {canChangeDevice ? (
-                devices.map((device, index) => (
-                  <option key={device.deviceId || device.label || index} value={device.deviceId || 'default'}>
-                    {device.label || `Микрофон ${index + 1}`}
-                  </option>
-                ))
-              ) : (
-                <option value="">Нет доступных устройств</option>
-              )}
-            </select>
-          </div>
-        </div>
+        <AudioRoomHeader
+          roomName={roomName}
+          participantName={participantName}
+          participantCount={participantCount}
+        />
+        <ParticipantList
+          participants={sortedParticipants}
+          volumes={playbackVolumes}
+          onVolumeChange={handleParticipantVolumeChange}
+        />
+        <AudioSettingsPanel
+          inputVolume={inputVolume}
+          onInputVolumeChange={handleInputVolumeChange}
+          noiseCancellationEnabled={noiseCancellationEnabled}
+          onNoiseCancellationToggle={handleNoiseCancellationChange}
+          devices={devices}
+          canChangeDevice={canChangeDevice}
+          currentDeviceId={currentDeviceId}
+          onDeviceChange={handleDeviceChange}
+        />
         <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
           <ControlBar
             controls={{ microphone: true, camera: false, screenShare: false, chat: false, leave: true }}
@@ -464,7 +664,7 @@ export default function RoomPage() {
           onNoiseCancellationToggle={(enabled) => setNoiseCancellationEnabled(enabled)}
         />
       )}
-      <RoomAudioRenderer />
+      {roomType === 'Video' ? <RoomAudioRenderer /> : null}
     </LiveKitRoom>
   );
 }

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -16,12 +16,6 @@
 {$TALKIE_DOMAIN} {
     encode gzip
 
-    handle_path /_next/static/* {
-        root * /srv/app/.next/static
-        file_server
-        header Cache-Control "public, max-age=31536000, immutable"
-    }
-
     reverse_proxy web:3000
 
     # Access log for this site

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -22,8 +22,6 @@ services:
       dockerfile: infra/docker/node-web.Dockerfile
       args:
         - NEXT_PUBLIC_API_URL=https://${API_TALKIE_DOMAIN}
-    volumes:
-      - next_build:/app/.next            # <— writes build here
     env_file:
       - .env
     expose:
@@ -70,7 +68,6 @@ services:
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
-      - next_build:/srv/app/.next:ro
     ports:
       - "46.62.140.249:80:80/tcp"
       - "46.62.140.249:443:443/tcp"
@@ -81,7 +78,6 @@ services:
 
 volumes:
   caddy_data:
-  next_build:
 
 
 networks:


### PR DESCRIPTION
## Summary
- extend the API to describe room types and include the type in join responses
- add an audio-focused room experience with participant list, device picker, and input volume control powered by a custom gain processor
- update the lobby to show room types so users can choose audio or video spaces

## Testing
- `npm run typecheck` *(fails: TS5083 cannot read /workspace/talkie/tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68f8d65682f8832681f3b2ff23f40acf