### PR TITLE
Remove external TURN server references from LiveKit config

### DIFF
--- a/infra/docker/coturn-entrypoint.sh
+++ b/infra/docker/coturn-entrypoint.sh
@@ -30,6 +30,6 @@ exec turnserver \
   --min-port=29000 \
   --max-port=29200 \
   --tls-listening-port=443 \
-  --external-ip=65.109.242.173 \
+  --external-ip=46.62.140.249 \
   --cert="${CERT_FILE}" \
   --pkey="${KEY_FILE}"

--- a/infra/livekit/livekit.yaml
+++ b/infra/livekit/livekit.yaml
@@ -1,26 +1,12 @@
 # Minimal LiveKit config
 port: 7880
 rtc:
-  # tcp_port: 7881
+  tcp_port: 7881
   port_range_start: 50000
   port_range_end: 50200
   use_external_ip: true
-  # This allows the server to discover its own public IP address
-  # stun_servers:
-  #   - coturn:3478
-    # - stun.rtc.yandex.net:3478
-    # - turn.talkie.k1nval.com:3478
-  turn_servers:
-    # - host: turn.talkie.k1nval.com
-    #   port: 3478
-    #   protocol: udp
-    #   username: turnuser
-    #   credential: turn456
-    - host: turn.talkie.k1nval.com
-      port: 443
-      protocol: tls
-      username: turnuser
-      credential: turn456
+  # Allow the server to discover its public IP address so clients can
+  # attempt direct peer connections when possible.
 # Keys are now passed to the LiveKit container via environment variables
 # in the docker-compose.yml file for better security and flexibility.
 logging:


### PR DESCRIPTION
## Summary
- enable LiveKit's TCP transport on port 7881 and rely on default public STUN servers
- drop the custom TURN/STUN host entries to avoid referencing the powered-off relay
- point the coturn entrypoint's external IP to the primary host so no other addresses remain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9eebe7da08326a248a90464688182