### PR TITLE
Remove CSP headers from proxies

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -16,6 +16,11 @@
 {$TALKIE_DOMAIN} {
     encode gzip
 
+    # Remove Content-Security-Policy so we can test without CSP headers.
+    header {
+        -Content-Security-Policy
+    }
+
     reverse_proxy web:3000
 
     # Access log for this site
@@ -28,6 +33,10 @@
 
 # API
 {$API_TALKIE_DOMAIN} {
+    header {
+        -Content-Security-Policy
+    }
+
     reverse_proxy api:3001
 
     log {
@@ -39,6 +48,10 @@
 
 # LiveKit WS/HTTP
 {$LIVEKIT_TALKIE_DOMAIN} {
+    header {
+        -Content-Security-Policy
+    }
+
     reverse_proxy livekit:7880
 
     log {

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -27,6 +27,9 @@ http {
     listen 80;
     server_name _;
 
+    # Strip any Content-Security-Policy header so we can test without CSP.
+    proxy_hide_header Content-Security-Policy;
+
     # Web app
     location / {
       proxy_pass http://web;


### PR DESCRIPTION
## Summary
- strip the Content-Security-Policy header from all Caddy reverse proxy sites so testing can run without CSP
- hide the Content-Security-Policy header in the nginx config for the same reason when that proxy is used

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68fa63e62d848326b095fb5f49d7cfe4