### PR TITLE
Proxy Next.js assets through /static prefix

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,9 +1,37 @@
+const normalizeAssetPrefix = (prefix) => {
+  if (!prefix) {
+    return '';
+  }
+
+  if (prefix === '/') {
+    return '';
+  }
+
+  const withoutTrailing = prefix.replace(/\/+$/, '');
+
+  if (/^https?:\/\//.test(withoutTrailing)) {
+    return withoutTrailing;
+  }
+
+  const withoutLeading = withoutTrailing.replace(/^\/+/, '');
+
+  return withoutLeading ? `/${withoutLeading}` : '';
+};
+
+const rawAssetPrefix = process.env.NEXT_PUBLIC_ASSET_PREFIX ?? '/static';
+const assetPrefix = normalizeAssetPrefix(rawAssetPrefix) || '/static';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   // Disable minification and expose source maps to aid debugging production issues
   swcMinify: false,
   productionBrowserSourceMaps: true,
+  assetPrefix,
+  images: {
+    loader: 'default',
+    path: `${assetPrefix}/_next/image`,
+  },
   webpack(config, { dev }) {
     if (!dev) {
       config.optimization.minimize = false;

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -21,7 +21,16 @@
         -Content-Security-Policy
     }
 
-    reverse_proxy web:3000
+    route {
+        # Proxy Next.js build assets through a friendlier /static prefix to
+        # avoid exposing /_next directly.
+        handle_path /static/_next/* {
+            uri strip_prefix /static
+            reverse_proxy web:3000
+        }
+
+        reverse_proxy web:3000
+    }
 
     # Access log for this site
     log {

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -30,6 +30,14 @@ http {
     # Strip any Content-Security-Policy header so we can test without CSP.
     proxy_hide_header Content-Security-Policy;
 
+    # Next.js build assets are exposed through /static to avoid the /_next
+    # prefix that some regional filters target.
+    location ~ ^/static/_next/(.*)$ {
+      proxy_pass http://web/_next/$1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     # Web app
     location / {
       proxy_pass http://web;


### PR DESCRIPTION
## Summary
- default the Next.js app to serve build assets from a configurable `/static` asset prefix and update the image loader path for future CDNs
- update the Caddy reverse proxy to rewrite `/static/_next/*` requests back to the Next.js origin so clients no longer hit `/_next`
- add the same `/static/_next/*` rewrite to the fallback Nginx config for parity

## Testing
- npm --prefix apps/web run build

------
https://chatgpt.com/codex/tasks/task_e_68fa7acce86c8326a896d3d57c89de06